### PR TITLE
feat: LLM client — Claude wrapper with retry and token tracking

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -200,6 +200,10 @@ class LLMClient:
 
         if force_bedrock_bearer:
             token = os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "")
+            if not token:
+                raise LLMError(
+                    "force_bedrock_bearer=True but AWS_BEARER_TOKEN_BEDROCK is not set."
+                )
             region = os.environ.get("AWS_REGION", "us-west-2")
             self.auth_method = "bedrock_bearer"
             self._client = _BedrockBearerClient(bearer_token=token, region=region)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -818,6 +818,19 @@ class TestLLMClientEdgeCases(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             list(client.stream(system="s", user="u"))
 
+    def test_force_bedrock_bearer_empty_token_raises(self):
+        """force_bedrock_bearer=True with no token raises LLMError."""
+        env = {k: v for k, v in os.environ.items()
+               if k != "AWS_BEARER_TOKEN_BEDROCK"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.dict("sys.modules", {
+                "anthropic": _anthropic_mock,
+                "anthropic_bedrock": _anthropic_bedrock_mock,
+            }):
+                with self.assertRaises(LLMError) as ctx:
+                    LLMClient(force_bedrock_bearer=True)
+        self.assertIn("AWS_BEARER_TOKEN_BEDROCK", str(ctx.exception))
+
     def test_force_bedrock_unavailable_raises(self):
         """force_bedrock=True raises LLMError when AnthropicBedrock is not installed."""
         original = llm_client._BEDROCK_AVAILABLE


### PR DESCRIPTION
Closes #1

## Summary
- Thin wrapper around Anthropic SDK supporting API key and Bedrock auth
- Auto-detects auth: `ANTHROPIC_API_KEY` env var preferred, Bedrock fallback
- Retry with exponential backoff on 429 and 5xx (max 3 retries)
- Token usage tracking per call and cumulatively
- Cost estimation: Sonnet $3/$15, Opus $5/$25, Haiku $1/$5 per 1M tokens
- `get_usage_summary()` returns totals and estimated cost
- `stream()` method for long outputs
- Default model: `claude-sonnet-4-6`

## Test Plan
- 35 unit tests with fully mocked SDK, all pass
- 4 integration test stubs (skipped without real credentials)
- 98% code coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new code that performs authenticated LLM/Bedrock network calls (including a raw HTTP bearer-token path) and implements retry/backoff and cost tracking; mistakes could impact reliability or accidentally increase usage/cost. Changes are mostly additive and well-covered by tests, limiting blast radius.
> 
> **Overview**
> Introduces a new `LLMClient` wrapper for Claude with auto-detected authentication (`ANTHROPIC_API_KEY`, Bedrock IAM via `AnthropicBedrock`, or `AWS_BEARER_TOKEN_BEDROCK` via raw HTTP), plus optional forcing of Bedrock modes.
> 
> Adds retry-with-exponential-backoff for 429/5xx in `call()`, streaming support via `stream()`, and cumulative token/cost tracking (`call_history`, `get_usage_summary()` with model-based pricing). Includes a comprehensive new test suite with mocked unit tests and skipped-by-default integration tests for API key and Bedrock (IAM and bearer token) paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 027c9b60e693b1ce2715ffffcfe9a42a507c7698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->