### PR TITLE
Add CI workflow for integration tests with API keys

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,94 @@
+# Integration Tests for places-research
+# Runs tests against real LLM and search APIs using repository secrets.
+#
+# COST ESTIMATE: Each run makes ~5-10 LLM calls using Claude Sonnet.
+# Estimated cost: ~$0.50-1.00 per run. Scheduled weekly (Monday 6am UTC)
+# to keep costs manageable. Trigger manually via workflow_dispatch as needed.
+
+name: Integration Tests
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 6am UTC (save costs)
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to test'
+        default: 'main'
+
+jobs:
+  integration-test:
+    name: Integration Tests (Real APIs)
+    runs-on: ubuntu-latest
+    # Only run if secrets are available (skip for forks)
+    if: github.repository == 'wangmiao1981/places-research'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || 'main' }}
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run integration tests
+      env:
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+        AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        PYTHONPATH: src
+      run: |
+        python -m pytest tests/test_integration_llm_stages.py -v --tb=short \
+          --junit-xml=integration-test-results.xml
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-test-results
+        path: integration-test-results.xml
+
+    - name: Create GitHub issue on failure
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const branch = context.eventName === 'workflow_dispatch'
+            ? (context.payload.inputs && context.payload.inputs.branch) || 'main'
+            : 'main (scheduled)';
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `Integration tests failed on ${branch}`,
+            body: [
+              '## Integration Test Failure',
+              '',
+              `**Branch:** \`${branch}\``,
+              `**Workflow run:** ${runUrl}`,
+              `**Triggered by:** ${context.eventName}`,
+              '',
+              'The weekly integration test run against real APIs failed.',
+              'Please investigate the run logs and resolve any failures.',
+              '',
+              '> This issue was created automatically by the Integration Tests workflow.',
+            ].join('\n'),
+            labels: ['bug', 'integration-tests'],
+          });

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,10 +75,32 @@ jobs:
           const branch = context.eventName === 'workflow_dispatch'
             ? (context.payload.inputs && context.payload.inputs.branch) || 'main'
             : 'main (scheduled)';
+          const title = `Integration tests failed on ${branch}`;
+
+          // Check for an existing open issue with the same title to avoid duplicates
+          const { data: existing } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'bug',
+            per_page: 100,
+          });
+          const duplicate = existing.find(issue => issue.title === title);
+          if (duplicate) {
+            // Add a comment to the existing issue instead of creating a new one
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: duplicate.number,
+              body: `Integration tests failed again.\n\n**Workflow run:** ${runUrl}\n**Triggered by:** ${context.eventName}`,
+            });
+            return;
+          }
+
           await github.rest.issues.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: `Integration tests failed on ${branch}`,
+            title,
             body: [
               '## Integration Test Failure',
               '',

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,6 +46,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
 
     - name: Run integration tests
       env:
@@ -90,5 +91,5 @@ jobs:
               '',
               '> This issue was created automatically by the Integration Tests workflow.',
             ].join('\n'),
-            labels: ['bug', 'integration-tests'],
+            labels: ['bug'],
           });


### PR DESCRIPTION
## Summary
Closes #26

Adds a new GitHub Actions workflow (`integration-tests.yml`) that runs integration tests against real Anthropic and Tavily APIs.

- **Weekly schedule**: Monday 6am UTC to keep costs low (~$0.50-1.00/run)
- **On-demand trigger**: `workflow_dispatch` with optional branch input
- **Fork safety**: Skips on forks that lack secrets
- **Failure alerting**: Auto-creates a GitHub issue on failure with link to the run
- **Secrets**: `ANTHROPIC_API_KEY`, `TAVILY_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, `AWS_REGION`
- **Artifacts**: JUnit XML test results uploaded on every run

## Test plan
- [ ] Workflow file is valid YAML
- [ ] Manual trigger works via Actions tab
- [ ] Secrets are not exposed in logs
- [ ] Issue is created on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a scheduled/manual GitHub Actions workflow that runs tests against real external APIs using repository secrets and auto-files GitHub issues on failure, which could incur cost or create noise if misconfigured.
> 
> **Overview**
> Adds a new `Integration Tests` GitHub Actions workflow (`.github/workflows/integration-tests.yml`) that runs `pytest tests/test_integration_llm_stages.py` against real Anthropic/Tavily (and optional Bedrock) credentials on a weekly schedule and via manual dispatch (with a branch input).
> 
> The workflow caches Python deps, uploads JUnit XML results as an artifact, skips execution on forks via a repo guard, and on failure creates (or comments on) a `bug` issue linking to the failed run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffb84093cb67d0f338511e2adcd26de33e0110c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->